### PR TITLE
Add configurable logging and replace prints

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,8 @@
 
 import os, asyncio, time, csv
+import logging
 from dotenv import load_dotenv
+from logging_config import setup_logging
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.client.default import DefaultBotProperties
@@ -15,6 +17,8 @@ from i18n import t
 
 # --------------- ENV & INIT ---------------
 load_dotenv()
+setup_logging()
+logger = logging.getLogger(__name__)
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 OWNER_ID = int(os.getenv("OWNER_ID", "0"))
@@ -276,9 +280,9 @@ def load_extensions():
             m = importlib.import_module(f"extensions.{mod}")
             if hasattr(m, "register"):
                 m.register(dp, bot, db, t, lang_for, OWNER_ID)
-                print(f"[ext] loaded: {mod}")
+                logger.info(f"[ext] loaded: {mod}")
         except Exception as e:
-            print(f"[ext] error loading {mod}: {e}")
+            logger.error(f"[ext] error loading {mod}: {e}")
 
 # --------------- ENTRYPOINT ---------------
 async def main():

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,9 @@
+import os
+import logging
+
+def setup_logging():
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(level=level,
+                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+


### PR DESCRIPTION
## Summary
- add logging_config module to centralize log setup via LOG_LEVEL env variable
- configure bot to use module-level logger and replace print statements with logger calls

## Testing
- `python -m py_compile bot.py logging_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e0ce390832fa975cffbe2d60897